### PR TITLE
Fix PKCS12 load order for openssl 3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["pki", "x509", "certificate", "tls"]
 edition = "2021"
 
 [dependencies]
+openssl-sys = "0.9"
 openssl = "0.10"
 thiserror = "1"
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,10 @@
+use std::env;
+
+fn main() {
+    if let Ok(v) = env::var("DEP_OPENSSL_VERSION_NUMBER") {
+        let version = u64::from_str_radix(&v, 16).unwrap();
+        if version >= 0x3_00_00_00_0 {
+            println!("cargo:rustc-cfg=openssl_3_0");
+        }
+    }
+}

--- a/src/model.rs
+++ b/src/model.rs
@@ -298,7 +298,10 @@ impl KeyStore {
         let parsed = pkcs12.parse(password)?;
         let mut certs: Vec<Certificate> = vec![parsed.cert.into()];
         if let Some(chain) = parsed.chain {
+            #[cfg(not(openssl_3_0))]
             certs.extend(chain.into_iter().rev().map(Into::into));
+            #[cfg(openssl_3_0)]
+            certs.extend(chain.into_iter().map(Into::into));
         }
         Ok(Self {
             private_key: PrivateKey(parsed.pkey),


### PR DESCRIPTION
The ordering of pkcs12_parse has been altered in OpenSSL 3.0. (https://github.com/openssl/openssl/issues/6698 and https://github.com/openssl/openssl/blob/2628de72b93534fec09336e28ab572b542a16885/CHANGES.md?plain=1#L1727)

Without this modification, the parsed cert chain would have its ca order reversed and fail the test on machines with OpenSSL 3.0 installed.