### PR TITLE
Allow creation of client & server auth cert

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -45,6 +45,7 @@ pub enum CertUsage {
     CA,
     TlsServer,
     TlsClient,
+    TlsServerAndClient,
     CodeSign,
 }
 
@@ -56,6 +57,7 @@ impl CertUsage {
             Self::TlsServer => "serverAuth",
             Self::TlsClient => "clientAuth",
             Self::CodeSign => "codeSigning",
+            Self::TlsServerAndClient => "serverAuth,clientAuth",
         }
     }
 
@@ -63,7 +65,7 @@ impl CertUsage {
     pub fn usage(&self) -> &'static str {
         match self {
             Self::CA => "keyCertSign,cRLSign",
-            Self::TlsServer | Self::TlsClient => {
+            Self::TlsServer | Self::TlsClient | Self::TlsServerAndClient => {
                 "digitalSignature,nonRepudiation,keyEncipherment,dataEncipherment"
             }
             Self::CodeSign => "digitalSignature,nonRepudiation",


### PR DESCRIPTION
I have a specific use case where I need to use the same cert to do server and client auth. I believe this use pattern is common and can be supported in this crate.